### PR TITLE
Fix compilation errors with clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ cmake-build-*
 
 *.a
 *.arc
+*.bc
 *.d
 *.dylib*
 *.gcda

--- a/Makefile
+++ b/Makefile
@@ -217,12 +217,7 @@ LIB_SOURCES += utilities/env_librados.cc
 LDFLAGS += -lrados
 endif
 
-ROCKSDB_ON_DCPMM := 1
-
-ifdef ROCKSDB_ON_DCPMM
-LDFLAGS += -L/usr/local/lib/ -L/usr/local/lib64/ -lpmem -lpmemobj
-CXXFLAGS += -I/usr/local/include -DON_DCPMM
-endif
+include dcpmm.mk
 
 AM_LINK = $(AM_V_CCLD)$(CXX) $^ $(EXEC_LDFLAGS) -o $@ $(LDFLAGS) $(COVERAGEFLAGS)
 

--- a/dcpmm.mk
+++ b/dcpmm.mk
@@ -1,0 +1,19 @@
+ROCKSDB_ON_DCPMM := 1
+
+ifdef ROCKSDB_ON_DCPMM
+
+ifdef PMDK_LIBRARY_PATH
+LDFLAGS += -L$(PMDK_LIBRARY_PATH) -Wl,-rpath=$(PMDK_LIBRARY_PATH)
+else
+LDFLAGS += -L/usr/local/lib/ -L/usr/local/lib64/
+endif
+LDFLAGS += -lpmem -lpmemobj
+
+ifdef PMDK_INCLUDE_PATH
+CXXFLAGS += -I$(PMDK_INCLUDE_PATH)
+else
+CXXFLAGS += -I/usr/local/include
+endif
+CXXFLAGS += -DON_DCPMM
+
+endif

--- a/dcpmm/kvs_dcpmm.cc
+++ b/dcpmm/kvs_dcpmm.cc
@@ -41,7 +41,7 @@ struct Pool {
 };
 
 struct PobjAction : pobj_action {
-  unsigned int pool_index;
+  size_t pool_index;
 };
 
 static struct Pool* pools_ = nullptr;
@@ -113,7 +113,7 @@ bool KVSEnabled() {
   return pools_ != nullptr;
 }
 
-static bool ReservePmem(size_t size, unsigned int* p_pool_index, PMEMoid* p_oid,
+static bool ReservePmem(size_t size, size_t* p_pool_index, PMEMoid* p_oid,
                         struct PobjAction* pact) {
   size_t pool_index = (next_pool_index_++) % pool_count_;
   size_t retry_loop = pool_count_;
@@ -281,7 +281,7 @@ void KVSDecodeValueRef(const char* input, size_t size, std::string* dst) {
       char* tmp_buf = new char[dst_len];
       Snappy_Uncompress(src_data, src_len, tmp_buf);
       dst->assign(tmp_buf, dst_len);
-      delete tmp_buf;
+      delete[] tmp_buf;
     } else {
       abort();
     }

--- a/dcpmm/kvs_dcpmm.h
+++ b/dcpmm/kvs_dcpmm.h
@@ -25,8 +25,8 @@ struct KVSRef {
   // Specify the encoding type of value content.
   struct KVSHdr hdr;
   // The size of value after encoding.
-  unsigned int size;
-  unsigned int pool_index;
+  size_t size;
+  size_t pool_index;
   // The offset of value on DCPMM in the pool.
   size_t off_in_pool;
 };

--- a/env/env_dcpmm.cc
+++ b/env/env_dcpmm.cc
@@ -43,7 +43,6 @@ DCPMMMmapFile::DCPMMMmapFile(const std::string& fname, int fd, size_t page_size,
       base_(nullptr),
       limit_(nullptr),
       dst_(nullptr),
-      last_sync_(nullptr),
       file_offset_(0) {
 #ifdef ROCKSDB_FALLOCATE_PRESENT
   allow_fallocate_ = options.allow_fallocate;

--- a/env/env_dcpmm.h
+++ b/env/env_dcpmm.h
@@ -30,7 +30,6 @@ class DCPMMMmapFile : public FSWritableFile {
   char* base_;
   char* limit_;
   char* dst_;
-  char* last_sync_;
   uint64_t file_offset_;
 #ifdef ROCKSDB_FALLOCATE_PRESENT
   bool allow_fallocate_;  // If false, fallocate calls are bypassed

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -12,6 +12,9 @@ ifneq ($(USE_RTTI), 1)
 	CXXFLAGS += -fno-rtti
 endif
 
+include ../dcpmm.mk
+EXEC_LDFLAGS += $(LDFLAGS)
+
 .PHONY: clean librocksdb
 
 all: simple_example column_families_example compact_files_example c_simple_example optimistic_transaction_example transaction_example compaction_filter_example options_file_example

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -660,7 +660,7 @@ Status GetStringFromStruct(
     std::string* opt_string) {
   assert(opt_string);
   opt_string->clear();
-  for (const auto iter : type_info) {
+  for (const auto &iter : type_info) {
     const auto& opt_info = iter.second;
     // If the option is no longer used in rocksdb and marked as deprecated,
     // we skip it in the serialization.


### PR DESCRIPTION
- Remove unused private field
- Change fields to size_t to avoid implicit narrowing
- Change iterator to reference
- Change `delete` to `delete[]`