### PR TITLE
Fix more clang compilation issues 

### DIFF
--- a/db/db_iter_stress_test.cc
+++ b/db/db_iter_stress_test.cc
@@ -97,7 +97,8 @@ struct StressTestIterator : public InternalIterator {
 
   bool MaybeFail() {
     if (rnd->Next() >=
-        std::numeric_limits<uint64_t>::max() * error_probability) {
+        static_cast<double>(std::numeric_limits<uint64_t>::max())
+          * error_probability) {
       return false;
     }
     if (rnd->Next() % 2) {
@@ -114,7 +115,8 @@ struct StressTestIterator : public InternalIterator {
 
   void MaybeMutate() {
     if (rnd->Next() >=
-        std::numeric_limits<uint64_t>::max() * mutation_probability) {
+        static_cast<double>(std::numeric_limits<uint64_t>::max())
+          * mutation_probability) {
       return;
     }
     do {
@@ -127,7 +129,9 @@ struct StressTestIterator : public InternalIterator {
         hide_probability = 1;
       }
       bool do_hide =
-          rnd->Next() < std::numeric_limits<uint64_t>::max() * hide_probability;
+          rnd->Next() <
+            static_cast<double>(std::numeric_limits<uint64_t>::max())
+              * hide_probability;
       if (do_hide) {
         // Hide a random entry.
         size_t idx = rnd->Next() % data->entries.size();

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -39,7 +39,7 @@ class DBOptionsTest : public DBTestBase {
     std::unordered_map<std::string, std::string> options_map;
     StringToMap(options_str, &options_map);
     std::unordered_map<std::string, std::string> mutable_map;
-    for (const auto opt : db_options_type_info) {
+    for (const auto &opt : db_options_type_info) {
       if (opt.second.IsMutable() && opt.second.ShouldSerialize()) {
         mutable_map[opt.first] = options_map[opt.first];
       }
@@ -57,7 +57,7 @@ class DBOptionsTest : public DBTestBase {
     std::unordered_map<std::string, std::string> options_map;
     StringToMap(options_str, &options_map);
     std::unordered_map<std::string, std::string> mutable_map;
-    for (const auto opt : cf_options_type_info) {
+    for (const auto &opt : cf_options_type_info) {
       if (opt.second.IsMutable() && opt.second.ShouldSerialize()) {
         mutable_map[opt.first] = options_map[opt.first];
       }

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -1047,7 +1047,7 @@ TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDConcurrent) {
 
     // Collect and check whether the IDs are unique.
     std::unordered_set<std::string> ids;
-    for (const std::string fname : fnames) {
+    for (const std::string &fname : fnames) {
       std::unique_ptr<RandomAccessFile> file;
       std::string unique_id;
       ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
@@ -1061,7 +1061,7 @@ TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDConcurrent) {
     }
 
     // Delete the files
-    for (const std::string fname : fnames) {
+    for (const std::string &fname : fnames) {
       ASSERT_OK(env_->DeleteFile(fname));
     }
 

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -228,7 +228,7 @@ class BlockConstructor: public Constructor {
     block_ = nullptr;
     BlockBuilder builder(table_options.block_restart_interval);
 
-    for (const auto kv : kv_map) {
+    for (const auto &kv : kv_map) {
       builder.Add(kv.first, kv.second);
     }
     // Open the block
@@ -352,7 +352,7 @@ class TableConstructor: public Constructor {
         TablePropertiesCollectorFactory::Context::kUnknownColumnFamily,
         file_writer_.get()));
 
-    for (const auto kv : kv_map) {
+    for (const auto &kv : kv_map) {
       if (convert_to_internal_key_) {
         ParsedInternalKey ikey(kv.first, kMaxSequenceNumber, kTypeValue);
         std::string encoded;
@@ -487,7 +487,7 @@ class MemTableConstructor: public Constructor {
                              kMaxSequenceNumber, 0 /* column_family_id */);
     memtable_->Ref();
     int seq = 1;
-    for (const auto kv : kv_map) {
+    for (const auto &kv : kv_map) {
       memtable_->Add(seq, kTypeValue, kv.first, kv.second);
       seq++;
     }
@@ -548,7 +548,7 @@ class DBConstructor: public Constructor {
     delete db_;
     db_ = nullptr;
     NewDB();
-    for (const auto kv : kv_map) {
+    for (const auto &kv : kv_map) {
       WriteBatch batch;
       batch.Put(kv.first, kv.second);
       EXPECT_TRUE(db_->Write(WriteOptions(), &batch).ok());
@@ -1224,7 +1224,7 @@ class FileChecksumTestHelper {
   }
 
   Status WriteKVAndFlushTable() {
-    for (const auto kv : kv_map_) {
+    for (const auto &kv : kv_map_) {
       if (convert_to_internal_key_) {
         ParsedInternalKey ikey(kv.first, kMaxSequenceNumber, kTypeValue);
         std::string encoded;

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -76,7 +76,7 @@ TEST_F(LdbCmdTest, HexToStringBadInputs) {
   const vector<string> badInputs = {
       "0xZZ", "123", "0xx5", "0x111G", "0x123", "Ox12", "0xT", "0x1Q1",
   };
-  for (const auto badInput : badInputs) {
+  for (const auto &badInput : badInputs) {
     try {
       ROCKSDB_NAMESPACE::LDBCommand::HexToString(badInput);
       std::cerr << "Should fail on bad hex value: " << badInput << "\n";


### PR DESCRIPTION
- Make const iterator variables references (fixes `-Werror,-Wrange-loop-construct`)
- Add explicit casts from `uint64_t` to `double`